### PR TITLE
Add 20 skills: Claude Cowork category (15) + Design Systems and UI category (5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-ready skills for Claude Code. Built and maintained by [OneWave AI](https://www.onewave-ai.com) -- AI consulting for small and mid-size businesses.
 
-**172 skills** across three pillars: **business** (sales, marketing, consulting, ops), **everyday life** (personal finance, travel, fitness, job hunting), and **coding** (engineering, design, AI agent architecture).
+**179 skills** across three pillars: **business** (sales, marketing, consulting, ops), **everyday life** (personal finance, travel, fitness, job hunting), and **coding** (engineering, design, AI agent architecture).
 
 ---
 
@@ -54,12 +54,25 @@ Skills built around specific Anthropic product releases.
 |-------|-------------|
 | `overnight-repo-auditor` | Uses Managed Agents (14.5hr runtime) for autonomous overnight codebase audits |
 | `multi-agent-client-onboarding` | Agent SDK: 3 parallel agents for client assessment |
-| `cowork-deal-room` | Cowork-style multi-step deal room document analysis |
 | `gmail-to-crm-pipeline` | MCP Connectors: Gmail to CRM lead qualification pipeline |
 | `full-codebase-migrator` | 1M context window: ingest entire codebases for migration planning |
 | `claude-design-system-architect` | Generate a premium design system (tokens, type, motion) exported to Tailwind/CSS |
 | `claude-landing-composer` | Build premium animated landing pages in Next.js + Framer Motion, anti-template |
 | `claude-design-critic` | Audit a UI and de-AI it — design + copy fixes toward editorial/premium |
+
+### Claude Cowork
+Folder-first knowledge-worker workflows built for Claude Cowork -- now with cloud sessions, scheduled tasks that run with no device online, and Microsoft 365 write tools (July 2026).
+
+| Skill | Description |
+|-------|-------------|
+| `cowork-deal-room` | Multi-step deal room due diligence -- contracts, financials, risk scoring |
+| `cowork-folder-organizer` | Turn a messy folder or shared drive into an organized, indexed workspace with an undo trail |
+| `cowork-inbox-triage` | Daily inbox sweep -- classify, draft replies in your voice, queue follow-ups; scheduled-task ready |
+| `cowork-hiring-screener` | Score a folder of resumes against the JD -- ranked shortlist with evidence, interview kits, drafts |
+| `cowork-expense-audit` | Reconcile receipts to statements, categorize, flag policy violations, output the expense report |
+| `cowork-rfp-response` | Shred an RFP into a compliance matrix, mine your past proposals, draft the response honestly |
+| `cowork-invoice-chaser` | AR aging report plus escalating dunning drafts matched to invoice age; weekly scheduled task |
+| `cowork-contract-renewal-radar` | Extract every auto-renew clause and notice window, calendar the real decision deadlines |
 
 ### Sales and Revenue
 | Skill | Description |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Production-ready skills for Claude Code. Built and maintained by [OneWave AI](https://www.onewave-ai.com) -- AI consulting for small and mid-size businesses.
 
-**188 skills** across three pillars: **business** (sales, marketing, consulting, ops), **everyday life** (personal finance, travel, fitness, job hunting), and **coding** (engineering, design, AI agent architecture).
+**193 skills** across three pillars: **business** (sales, marketing, consulting, ops), **everyday life** (personal finance, travel, fitness, job hunting), and **coding** (engineering, design, AI agent architecture).
+
+Companion repo: **[Open Agent Stack](https://github.com/OneWave-AI/open-agent-stack)** -- installable plugins, managed agents, multi-agent orchestrators, and 7 design-token themes. Skills here stay single-file and zero-dependency; anything with a manifest, a team, or a build step lives there.
 
 ---
 
@@ -148,13 +150,28 @@ Folder-first knowledge-worker workflows built for Claude Cowork -- now with clou
 | `regex-debugger` | Visual regex breakdown and debugging |
 | `performance-profiler` | Application performance profiling |
 | `api-endpoint-scaffolder` | REST API endpoint generation |
-| `responsive-layout-builder` | CSS Grid, Flexbox, container queries |
 | `react-component-generator` | React components with TypeScript and a11y |
+| `database-schema-designer` | Optimized schemas with ERD diagrams |
+| `landing-page-optimizer` | Conversion and performance optimization |
+
+### Design Systems and UI
+Build, install, and enforce design systems. Pairs with the 7 ready-made design-token themes in [Open Agent Stack `design-styles/`](https://github.com/OneWave-AI/open-agent-stack/tree/main/design-styles) -- aurora-mesh, cirrus, liquid-glass, mono-brutalist, neo-terminal, sand-terra, tidal.
+
+| Skill | Description |
+|-------|-------------|
+| `design-style-installer` | Install a complete token theme (from Open Agent Stack or local tokens.json) and repaint the project |
+| `design-tokens-sync` | Find and fix token drift -- stale copies, hardcoded values, orphans -- plus a CI guard |
+| `motion-language-designer` | Duration/easing scales, choreography rules, signature moves -> Framer Motion + CSS |
+| `dark-mode-converter` | Real dark mode via semantic tokens and elevation logic, not naive inversion |
+| `typography-scale-builder` | Fluid type scale with per-step line-height/tracking, roles, vertical rhythm |
 | `design-system-generator` | Design tokens, components, documentation |
 | `css-animation-creator` | Professional animations and micro-interactions |
-| `database-schema-designer` | Optimized schemas with ERD diagrams |
+| `responsive-layout-builder` | CSS Grid, Flexbox, container queries |
 | `screenshot-to-code` | Convert UI screenshots to working code |
-| `landing-page-optimizer` | Conversion and performance optimization |
+| `color-palette-extractor` | Extract palettes from images or sites -- HEX/RGB/Tailwind/CSS variables |
+| `font-pairing-suggester` | Font pairings with hierarchy and loading strategy |
+| `brand-consistency-checker` | Scan documents and slides for off-brand colors, fonts, logos |
+| `accessibility-auditor` | WCAG compliance audit and fixes |
 
 ### Security and Compliance
 | Skill | Description |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-ready skills for Claude Code. Built and maintained by [OneWave AI](https://www.onewave-ai.com) -- AI consulting for small and mid-size businesses.
 
-**180 skills** across three pillars: **business** (sales, marketing, consulting, ops), **everyday life** (personal finance, travel, fitness, job hunting), and **coding** (engineering, design, AI agent architecture).
+**188 skills** across three pillars: **business** (sales, marketing, consulting, ops), **everyday life** (personal finance, travel, fitness, job hunting), and **coding** (engineering, design, AI agent architecture).
 
 ---
 
@@ -73,6 +73,14 @@ Folder-first knowledge-worker workflows built for Claude Cowork -- now with clou
 | `cowork-rfp-response` | Shred an RFP into a compliance matrix, mine your past proposals, draft the response honestly |
 | `cowork-invoice-chaser` | AR aging report plus escalating dunning drafts matched to invoice age; weekly scheduled task |
 | `cowork-contract-renewal-radar` | Extract every auto-renew clause and notice window, calendar the real decision deadlines |
+| `cowork-data-room-builder` | Prep YOUR data room for a raise or acquisition -- checklist, gap report, organized structure |
+| `cowork-vendor-comparison` | Normalize vendor quotes into one matrix -- true TCO, buried terms, negotiation leverage |
+| `cowork-qbr-builder` | Client folder -> QBR with value receipts, honest misses, health read, expansion asks |
+| `cowork-sop-writer` | Turn a process walkthrough into a clean SOP -- steps, decision points, tribal knowledge captured |
+| `cowork-calendar-defrag` | Measure meeting load and fragmentation, propose cuts and focus blocks, draft the decline messages |
+| `cowork-tax-prep-organizer` | Sweep folders for tax docs, build the CPA-ready package and the missing-form chase list |
+| `cowork-medical-bill-auditor` | Match bills to EOBs, catch overbilling and unsubmitted claims, draft dispute letters |
+| `cowork-home-inventory` | Photos + receipts -> insurance-grade home inventory with values, serials, and the gap list |
 
 ### Sales and Revenue
 | Skill | Description |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-ready skills for Claude Code. Built and maintained by [OneWave AI](https://www.onewave-ai.com) -- AI consulting for small and mid-size businesses.
 
-**179 skills** across three pillars: **business** (sales, marketing, consulting, ops), **everyday life** (personal finance, travel, fitness, job hunting), and **coding** (engineering, design, AI agent architecture).
+**180 skills** across three pillars: **business** (sales, marketing, consulting, ops), **everyday life** (personal finance, travel, fitness, job hunting), and **coding** (engineering, design, AI agent architecture).
 
 ---
 

--- a/cowork-calendar-defrag/SKILL.md
+++ b/cowork-calendar-defrag/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: cowork-calendar-defrag
+description: Audit your calendar with Cowork's calendar tools -- measure meeting load and fragmentation, identify which recurring meetings earn their slot, propose consolidations and focus blocks, and draft the diplomatic messages that reclaim your week.
+tools: Read, Write, Bash
+model: inherit
+---
+
+# Cowork Calendar Defrag
+
+Treat the calendar like a disk that needs defragmenting: measure what is actually there, identify waste, consolidate, and carve out contiguous space for real work. Uses the connected calendar tools (Microsoft 365 / Google Calendar) to read events; every change is proposed, and the human approves before anything is created, moved, or declined.
+
+## Workflow
+
+1. **Measure.** Pull the last 4 weeks and the next 2. Compute: hours in meetings per week, longest uninterrupted block per day, fragmentation score (count of gaps under 45 minutes -- too short to do real work, long enough to lose), meetings by type (recurring vs. ad hoc, internal vs. external), and after-hours creep.
+2. **Score the recurring load.** For each recurring meeting: duration x frequency x attendee count = weekly cost. Flag candidates against the classic tells -- no agenda in the invite, attendance optional-in-practice, could-be-async status updates, double-booked slots the user routinely skips. External and client meetings are measured but never flagged for cuts without explicit instruction.
+3. **Propose the defrag.** A specific plan, not principles: which recurrings to shorten (60 -> 25), consolidate (three 1:1s into office hours), make async, or leave alone; where the 2-3 weekly focus blocks go (matched to when the calendar shows the user actually has energy-adjacent free space, e.g. mornings); and which small gaps to close by nudging meetings adjacent.
+4. **Draft the messages.** For each proposed change involving other people: a short, warm, blame-free draft ("I'm consolidating my recurring syncs -- can we fold this into..."). The awkward message is the real barrier to a better calendar; remove it.
+5. **Execute on approval.** Create the focus blocks (marked busy, named for the work), send nothing -- updated invites and messages remain drafts for the human to send. Output `calendar-defrag-report.md` with before/after metrics: meeting hours reclaimed, longest block gained.
+
+## Rules
+
+- Read freely, write only what was approved, send nothing. Calendars are shared surfaces; a wrong move is publicly visible.
+- Never propose cutting external, client, or 1:1-with-manager meetings unless the user asked for a full-scope review.
+- Fragmentation is the enemy, not meetings. Six hours of meetings in two blocks beats four hours scattered across nine slots.
+- Focus blocks get names ("Proposal writing") -- anonymous "Busy" blocks get scheduled over within two weeks.
+- Respect the user's stated no-touch zones (school pickup, gym, standing personal events) as hard constraints.
+- Re-run comparisons honestly: if the defrag did not hold (blocks got booked over), report it and diagnose which changes stuck.
+
+## Scheduled Mode
+
+As a monthly Cowork scheduled task: re-measure, compare against the last report, flag regression (creeping recurrings, eroded focus blocks), and propose the next round of cuts.
+
+## Quick Commands
+
+- "Audit my calendar" -- steps 1-2, the measurement and scorecard
+- "Defrag my week" -- full workflow
+- "Where can I fit 3 hours of deep work?" -- focus-block placement only
+- "Draft the decline for [meeting]" -- one diplomatic message

--- a/cowork-contract-renewal-radar/SKILL.md
+++ b/cowork-contract-renewal-radar/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: cowork-contract-renewal-radar
+description: Sweep a contracts folder and extract every renewal date, auto-renew clause, notice window, and price-escalation term into a renewal calendar -- then create calendar reminders ahead of each notice deadline via Cowork's calendar write tools. The skill that stops auto-renewals from ambushing you.
+tools: Read, Glob, Grep, Write, Bash
+model: inherit
+---
+
+# Cowork Contract Renewal Radar
+
+Read a folder of contracts the way outside counsel prepping a renewal calendar does: find every date-driven obligation, compute the real decision deadline (notice deadline, not renewal date), and put it somewhere it will actually be seen. Complements `contract-analyzer` (deep single-contract review) -- this skill is the portfolio sweep.
+
+## Workflow
+
+1. **Inventory.** Catalog every contract in the folder (PDF, .docx): counterparty, contract type (vendor, customer, lease, SaaS subscription, employment, NDA), and executed vs. draft status. Skip drafts but list them.
+2. **Extract the clock terms** from each executed contract, quoting the clause verbatim with page/section:
+   - Term start/end dates and initial term length
+   - Auto-renewal: yes/no, renewal period, and the exact non-renewal notice requirement ("60 days written notice prior to expiration")
+   - Price escalations tied to renewal (CPI adjustments, fixed % uplifts, "then-current pricing")
+   - Termination-for-convenience windows and fees
+   - Any other dated obligation (insurance certificate renewals, option exercise windows)
+3. **Compute decision deadlines.** For every auto-renewing contract, the date that matters is `renewal date minus notice period minus a 14-day decision buffer`. That is the radar date. Contracts already inside their notice window get flagged `URGENT` at the top of the report.
+4. **Build the calendar.** Write `renewal-calendar.md`: chronological table of radar dates for the next 24 months with counterparty, annual value (when stated), what happens if nothing is done, and the verbatim notice clause. Separately list contracts with no end date or missing signature pages as data-quality issues.
+5. **Set reminders.** If calendar write tools (Microsoft 365 / Google Calendar) are connected, create an event on each radar date -- title `Renewal decision: [counterparty]`, description containing the notice deadline, clause quote, and file path -- after showing the user the list of events to be created and getting approval.
+
+## Rules
+
+- The notice deadline is the deliverable, not the renewal date. A calendar that reminds you on the renewal date is a calendar of things it is too late to change.
+- Quote clauses verbatim with location. Renewal terms are exactly where paraphrasing creates liability.
+- Never mark a contract "no auto-renewal" from silence -- distinguish "clause states no renewal" from "no renewal clause found," and flag the latter for human review.
+- Annual value comes from the contract only; no estimates.
+- This is calendaring support, not legal advice. Frame judgment calls as "counsel should confirm...".
+- On re-runs, diff against the previous calendar: new contracts, changed dates, and passed deadlines get called out first.
+
+## Scheduled Mode
+
+As a monthly Cowork scheduled task: re-sweep the folder for new/amended contracts, update the calendar, and deliver a digest leading with anything entering its decision window in the next 60 days.
+
+## Quick Commands
+
+- "Sweep [folder]" -- full workflow
+- "What's renewing this quarter?" -- filtered radar view
+- "Anything urgent?" -- contracts already inside their notice window
+- "Calendar it" -- step 5 against the existing report

--- a/cowork-data-room-builder/SKILL.md
+++ b/cowork-data-room-builder/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cowork-data-room-builder
+description: Prepare YOUR data room for a fundraise, acquisition, or bank diligence -- builds the checklist for your deal stage, sweeps your folders for what you already have, produces a gap report, and organizes everything into the structure buyers and investors expect. The sell-side complement to cowork-deal-room.
+tools: Read, Glob, Grep, Write, Bash, WebSearch
+model: inherit
+---
+
+# Cowork Data Room Builder
+
+Prepare a data room the way a banker's analyst does: know what the other side's diligence team will ask for before they ask, find it or flag it, and present it in the structure they expect. Inputs: the deal type (seed/Series A/growth round, acquisition, loan) and one or more folders of company documents.
+
+## Workflow
+
+1. **Build the request list.** Generate the diligence checklist for the stated deal type and stage: corporate records, cap table and securities, financials, material contracts, IP, employment, tax, insurance, litigation, and (for later stages) customer concentration and compliance. Present it for approval -- the user may know their acquirer's quirks.
+2. **Sweep.** Walk the provided folders and match every document to a checklist item. Classify each match `FINAL` (executed/signed), `DRAFT`, or `STALE` (superseded or older than the period requested). One file can satisfy multiple items.
+3. **Gap report.** Output the checklist with status per item: `HAVE`, `HAVE-BUT-DRAFT`, `HAVE-BUT-STALE`, `MISSING`. Rank the missing items by how early diligence will hit them (corporate formation docs and cap table before customer contracts). This report is the deliverable that saves the deal timeline.
+4. **Organize.** On approval, build the data room folder structure (numbered top-level sections matching the checklist), copy -- never move -- documents in with clean names (`3.2-msa-acme-corp-executed-2025.pdf`), and write `INDEX.md` mapping every checklist item to its file.
+5. **Red-flag pass.** Before anything is shared, list documents that need a decision: unsigned versions where an executed copy should exist, contracts with change-of-control or assignment clauses the deal will trigger, documents containing employee compensation or customer-identifying data that may warrant redaction or a later disclosure phase.
+
+## Rules
+
+- Copy, never move. The data room is a curated export; source folders stay untouched.
+- Never place a draft where a final belongs without labeling it `DRAFT` in the filename and index.
+- Never redact or exclude documents silently -- list redaction candidates and let counsel decide.
+- The gap report states what was searched, so "MISSING" means "not in the provided folders," not "does not exist."
+- Stage-appropriate depth: do not demand SOC 2 reports from a pre-seed company; do not omit them for a growth round.
+- This is preparation support, not legal or securities advice. Frame judgment calls for counsel.
+
+## Quick Commands
+
+- "Build the checklist for [deal type]" -- step 1 only
+- "What am I missing?" -- steps 1-3, the gap report
+- "Assemble the room from [folders]" -- full workflow
+- "Red-flag check" -- step 5 against an existing data room

--- a/cowork-expense-audit/SKILL.md
+++ b/cowork-expense-audit/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: cowork-expense-audit
+description: Cowork-style sweep of a folder of receipts, statements, and expense exports -- categorizes every transaction, matches receipts to statement lines, flags policy violations and anomalies, and outputs a clean expense report plus a findings memo.
+tools: Read, Glob, Grep, Write, Bash
+model: inherit
+---
+
+# Cowork Expense Audit
+
+Process an expense folder the way a careful controller does: reconcile receipts against statements, categorize consistently, and separate what is provably documented from what is missing. Input is a directory of receipts (PDF, images), card/bank statements, and any expense exports (.csv/.xlsx). Never invent an amount -- every number in the output traces to a source file.
+
+## Workflow
+
+1. **Inventory.** Catalog every file: receipts, statements, exports, and unclassifiable items. Note date ranges covered. If statements and receipts cover different periods, say so up front.
+2. **Extract transactions.** Build a master ledger from the statements/exports: date, merchant, amount, currency. From each receipt: merchant, date, total, tax, payment method, line items when legible.
+3. **Reconcile.** Match receipts to statement lines (exact amount+date first, then fuzzy within 3 days and small tip/FX variance). Output three lists: matched, statement lines with no receipt, receipts with no statement line.
+4. **Categorize** every transaction (meals, travel, software, equipment, client entertainment, etc.). Use the company's category list if provided; otherwise propose one and apply it consistently. Tag anything client-billable separately.
+5. **Flag.** Apply the policy if provided; otherwise apply defaults and label them as defaults: duplicate charges, weekend/holiday spend on business cards, round-number amounts, per-transaction limits exceeded, subscriptions appearing monthly with no owner, personal-looking merchants, and split transactions that dodge an approval threshold.
+6. **Report.** Write `expense-report.xlsx`-ready CSV (or .xlsx if the xlsx skill is available) with the full categorized ledger, plus `audit-findings.md`: totals by category, reconciliation gaps, flagged items each with severity and the specific source file cited, and a missing-documentation list to chase.
+
+## Rules
+
+- Never fabricate or estimate amounts. An unreadable receipt is logged as unreadable, not guessed.
+- Flags are questions, not accusations. Write "no receipt located for..." not "unauthorized spend."
+- Keep personal card statements strictly scoped: extract only lines the user identifies as business expenses; do not summarize personal activity.
+- Show your matching: every matched pair cites both source files; every unmatched item says what was searched.
+- Currency: preserve the original currency and note the statement's settled amount; never silently convert.
+- If more than 20% of transactions lack receipts, lead the findings memo with that fact -- it is the finding.
+
+## Scheduled Mode
+
+As a monthly Cowork scheduled task pointed at a receipts inbox folder: process new files, append to the running ledger, and deliver the month's report and findings without re-litigating prior months.
+
+## Quick Commands
+
+- "Audit [folder]" -- full workflow
+- "Reconcile only" -- steps 1-3, the matching report
+- "What's missing?" -- unmatched statement lines and the chase list
+- "Billable pull" -- client-billable transactions grouped by client

--- a/cowork-folder-organizer/SKILL.md
+++ b/cowork-folder-organizer/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: cowork-folder-organizer
+description: Cowork-style cleanup of a messy folder or shared drive -- classifies every file, proposes a target structure, renames to a consistent convention, deduplicates, and writes an index. Use on Downloads, Desktop, client folders, or team shared drives.
+tools: Read, Glob, Grep, Write, Bash
+model: inherit
+---
+
+# Cowork Folder Organizer
+
+Turn a chaotic folder into an organized, navigable workspace the way Claude Cowork works through a directory: inventory everything first, propose before moving, then execute with a full undo trail. Never destroy information -- every move is logged and reversible.
+
+## Input
+
+Take a directory path. If none is provided, ask for one. Confirm scope before touching anything: subdirectories included or not, and whether any paths are off-limits.
+
+## Workflow
+
+1. **Inventory.** Walk the directory. For every file record name, extension, size, modified date, and a one-line content summary (read headers/first lines for documents, metadata for media). Do not open files larger than 50MB; classify by name and type only.
+2. **Classify.** Group files into categories inferred from the actual contents -- not a generic template. Typical clusters: active project files, reference material, financial documents, contracts, media/assets, installers and archives, duplicates, junk (temp files, `~$` locks, empty files).
+3. **Detect duplicates.** Match by checksum first, then by near-identical names with version suffixes (`final`, `final2`, `v3`, `(1)`). Identify the canonical copy (newest complete version) and mark the rest.
+4. **Propose.** Present the target folder tree, the naming convention (default: `YYYY-MM-DD-descriptive-name.ext` for dated documents, `client-project-doctype` for client work), the duplicate resolution list, and the junk list. Wait for approval before moving anything.
+5. **Execute.** Create the structure, move and rename files, quarantine duplicates and junk into `_review-before-deleting/` -- never delete outright. Log every operation as `old-path -> new-path` in `_organizer-log.md`.
+6. **Index.** Write `INDEX.md` at the root: the new tree, what lives where, and a table of the 20 most recently active files so the owner can re-orient instantly.
+
+## Rules
+
+- Propose first, move second. Never reorganize without showing the plan.
+- Never delete. Quarantine to `_review-before-deleting/` and let the human pull the trigger.
+- Preserve anything that looks like the only copy of original work (contracts, signed PDFs, raw footage) in place if its location seems intentional.
+- Keep names human-readable. No hash suffixes, no ALL_CAPS, no spaces-to-underscores churn on files that are already well named.
+- If the folder is a shared drive, flag files other people may have links to before renaming them.
+- Report at the end: files processed, moved, renamed, duplicates found, space reclaimable.
+
+## Scheduled Mode
+
+When run as a recurring Cowork scheduled task (e.g. weekly on Downloads), skip the approval step only for previously approved rules: apply the established convention to new files, quarantine new junk, and post a summary of what moved. Anything that does not match an existing rule goes to `_needs-decision/` and is listed in the summary.
+
+## Quick Commands
+
+- "Organize [path]" -- full workflow with proposal
+- "Just show me the plan" -- phases 1-4 only, no changes
+- "Dedupe only" -- duplicate detection and quarantine, no restructuring
+- "Undo" -- reverse the last run from `_organizer-log.md`

--- a/cowork-hiring-screener/SKILL.md
+++ b/cowork-hiring-screener/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: cowork-hiring-screener
+description: Point Cowork at a folder of resumes plus a job description -- screens every candidate against the actual requirements, produces a ranked shortlist with evidence, drafts advance/decline emails, and builds interview kits for the top picks. Pairs with hiring-scorecard for the interview stage.
+tools: Read, Glob, Grep, Write, Bash
+model: inherit
+---
+
+# Cowork Hiring Screener
+
+Screen a resume pile the way a disciplined recruiter does: score against the written requirements, cite evidence from the resume for every score, and never let formatting quality masquerade as candidate quality. Input is a folder of resumes (PDF, .docx, text) and a job description; output is a defensible shortlist.
+
+## Workflow
+
+1. **Extract requirements.** Parse the JD into must-haves, nice-to-haves, and disqualifiers. Present the rubric for approval before scoring -- the human may reweight. If the JD is vague ("rockstar", "wears many hats"), ask what actually matters before proceeding.
+2. **Inventory.** Catalog every file in the folder. Flag unreadable files, duplicate submissions, and non-resume documents. Report the candidate count before starting.
+3. **Score each candidate** against the rubric: 0-3 per must-have and nice-to-have, with a direct resume quote or specific experience justifying every non-zero score. No quote, no points.
+4. **Rank and tier.** Produce `screening-report.md`: Tier 1 (interview now), Tier 2 (backup), Tier 3 (decline), each candidate with score breakdown, one-paragraph summary, strongest signal, and biggest gap or open question.
+5. **Draft communications.** Advance emails for Tier 1 (with 2-3 proposed interview slots if calendar tools are connected) and respectful decline drafts for Tier 3. Drafts only -- never send.
+6. **Interview kits.** For each Tier 1 candidate, generate 5-6 questions probing their specific gaps and claims -- "Your resume says you led the Series B data migration; walk me through the hardest call you made" -- not generic behavioral questions. Hand off to `hiring-scorecard` for structured interview evaluation.
+
+## Rules
+
+- Score the content, not the polish. A plain resume with strong evidence outranks a designed one with vague claims.
+- Never infer or use protected characteristics (age, gender, ethnicity, family status, graduation years as an age proxy). Score skills and experience only.
+- Distinguish "did the thing" from "was near the thing." "Led migration" and "team migrated during my tenure" are different scores.
+- Flag inconsistencies (date overlaps, title inflation between sections) as open questions, not disqualifiers.
+- Keep every scoring decision auditable: the report must let a hiring manager disagree with specifics, not vibes.
+- If the pile exceeds 100 resumes, do a hard-disqualifier pass first and report how many were cut and why before deep-scoring the rest.
+
+## Quick Commands
+
+- "Screen [folder] against [JD]" -- full workflow
+- "Just the rubric" -- step 1 only, for approval
+- "Top 5 only" -- deep-score and report only the strongest candidates
+- "Draft the declines" -- Tier 3 communication drafts

--- a/cowork-home-inventory/SKILL.md
+++ b/cowork-home-inventory/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: cowork-home-inventory
+description: Build an insurance-grade home inventory from a folder of photos and receipts -- identifies items, pulls values from receipts, estimates replacement costs, organizes by room, and outputs the documentation an insurance claim actually requires. Update mode keeps it current after new purchases.
+tools: Read, Glob, Grep, Write, Bash, WebSearch
+model: inherit
+---
+
+# Cowork Home Inventory
+
+Build the document everyone wishes they had after the fire, flood, or break-in: a room-by-room inventory with values and proof. Input: a folder of photos (room shots, close-ups, serial-number shots) and receipts (PDF, email exports, images). Output: a structured inventory file plus a gap list of what still needs documenting.
+
+## Workflow
+
+1. **Process the photos.** Identify items in each image: what it is, brand/model when visible, condition, and the room (from filename, folder structure, or visual context). Read serial numbers and model plates from close-ups. Group multiple angles of the same item.
+2. **Process the receipts.** Extract item, vendor, date, and price from every receipt. Match receipts to photographed items where possible -- a matched receipt upgrades an item from "estimated" to "documented."
+3. **Value the inventory.** For receipt-matched items: purchase price and date. For unmatched items: estimated replacement cost (current retail for an equivalent, via web search for significant items), clearly labeled `ESTIMATE`. Never present an estimate as a documented value.
+4. **Build the inventory.** Output `home-inventory.csv` (or .xlsx via the xlsx skill) -- room, item, brand/model, serial, purchase date, purchase price, replacement estimate, documentation status, photo filename(s), receipt filename -- plus `home-inventory-summary.md`: totals by room and category, the high-value items list, and overall documented vs. estimated ratio.
+5. **Gap list.** What insurance will ask for that is missing: high-value items with no receipt (jewelry, electronics, instruments -- may need appraisals or serial-number photos), rooms with no coverage, items where only a wide shot exists. Rank by value at risk. Suggest the 20-minute photo walk that closes the worst gaps.
+
+## Rules
+
+- Documented and estimated values never blend: every line is labeled, and the summary reports both totals separately.
+- Never inflate. Replacement estimates use realistic current retail for equivalent items, not premium substitutes.
+- Serial numbers are gold: capture every legible one, and put items that should have one but don't on the gap list.
+- Do not catalog people, documents with financial account numbers, or anything in photos beyond the possessions themselves.
+- Note policy-relevant thresholds generically ("many policies sub-limit jewelry; confirm your rider") without interpreting the user's actual policy -- unless the policy document is in the folder, in which case cite its stated limits next to the relevant categories.
+- Keep the inventory file local and note in the summary that a copy belongs somewhere that survives the house (cloud drive, safe deposit).
+
+## Update Mode
+
+Re-run on the same folder after adding new photos/receipts: append new items, update matched ones, preserve manual edits to the CSV, and report what changed. As a quarterly Cowork scheduled task, sweep the receipts/email-export folder and deliver the diff.
+
+## Quick Commands
+
+- "Inventory [folder]" -- full workflow
+- "What's undocumented?" -- step 5, the gap list
+- "Value check [item]" -- one replacement-cost lookup
+- "Update from new photos" -- update mode

--- a/cowork-inbox-triage/SKILL.md
+++ b/cowork-inbox-triage/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cowork-inbox-triage
+description: Daily inbox triage using Cowork's email write tools (Microsoft 365 or Gmail) -- classifies unread mail, drafts replies in your voice, flags what needs a decision, and schedules follow-ups. Built to run as a recurring Cowork scheduled task.
+tools: Read, Write, Bash, WebSearch
+model: inherit
+---
+
+# Cowork Inbox Triage
+
+Work an inbox the way a good chief of staff does: everything gets a disposition, nothing gets sent without approval, and the owner ends the run with a short list of real decisions instead of 80 unread threads. Uses the connected mail tools (Microsoft 365 or Gmail MCP connectors) for reading, labeling, and drafting.
+
+## Setup
+
+On first run, learn the owner's voice: read 10-15 sent replies and note greeting style, sign-off, sentence length, and formality. Store the profile in the conversation and reuse it for every draft. Ask once which categories matter (default set below) and what the auto-archive rules are.
+
+## Workflow
+
+1. **Sweep.** Pull unread and flagged threads from the last cycle (default: 24 hours). Group by thread, not message.
+2. **Classify** every thread into exactly one bucket:
+   - `NEEDS DECISION` -- only the owner can answer (pricing, commitments, personnel)
+   - `DRAFT READY` -- routine reply Claude can write for approval
+   - `WAITING ON THEM` -- owner already replied; schedule a follow-up check
+   - `FYI` -- no response needed; summarize in the digest
+   - `NOISE` -- newsletters, notifications, cold outreach; label/archive per the standing rules
+3. **Draft.** For every `DRAFT READY` thread, write the reply in the owner's voice as a draft -- never send. Keep drafts shorter than the email being answered.
+4. **Follow-ups.** For `WAITING ON THEM` threads past their expected response window (default 3 business days), draft a polite bump. For threads with dates in them, propose calendar holds via the calendar write tools.
+5. **Digest.** Post one summary: decisions needed (with one-line context and a recommended answer each), drafts awaiting approval, follow-ups queued, and a one-line count of what was archived.
+
+## Rules
+
+- Never send email. Create drafts only; the human sends.
+- Never archive anything that mentions money, contracts, legal matters, or a specific person's problem -- misclassified noise is recoverable, a missed client email is not.
+- A recommended answer accompanies every `NEEDS DECISION` item. Surfacing a question without a recommendation is half the job.
+- Quote the sender's actual ask in the digest -- do not paraphrase requests into vagueness.
+- Respect confidentiality: HR, health, and personal matters get flagged privately, never summarized in a shared channel.
+- If the connector lacks write scope, degrade gracefully: produce the digest and paste-ready reply texts instead of drafts.
+
+## Scheduled Mode
+
+As a Cowork scheduled task (weekday mornings), run the full workflow unattended in a cloud session and deliver the digest before the workday starts. Track threads across runs so a bump is never drafted twice for the same silence.
+
+## Quick Commands
+
+- "Triage my inbox" -- full run, last 24h
+- "Catch me up" -- sweep and digest only, no drafts
+- "Draft replies to everything easy" -- classification + drafts only
+- "Who am I waiting on?" -- the `WAITING ON THEM` ledger with days elapsed

--- a/cowork-invoice-chaser/SKILL.md
+++ b/cowork-invoice-chaser/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: cowork-invoice-chaser
+description: Point Cowork at your invoices and payments records -- builds an AR aging report, drafts escalating follow-up emails matched to each invoice's age and the client relationship, and runs as a weekly scheduled task so nothing slips past 30 days unnoticed.
+tools: Read, Glob, Grep, Write, Bash
+model: inherit
+---
+
+# Cowork Invoice Chaser
+
+Chase receivables the way a firm-but-warm operator does: know exactly who owes what and for how long, escalate on a schedule, and never send a dunning email to someone who already paid. Inputs: a folder of issued invoices (PDF/.docx) and payment evidence (bank exports, remittance emails, a payments .csv, or a paid-list the user maintains).
+
+## Workflow
+
+1. **Build the ledger.** Extract from every invoice: number, client, contact, issue date, due date, amount, terms. From payment records: date, amount, payer. Reconcile -- match payments to invoices (exact amount first, then partial payments, then aggregated payments covering multiple invoices).
+2. **Age the book.** Produce the AR aging report: current, 1-30, 31-60, 61-90, 90+ days past due, by client. Include total outstanding, weighted average days late, and the three largest exposures.
+3. **Flag before chasing.** List invoices with ambiguous payment status (partial matches, unidentified deposits near the amount) separately. These get a human decision, not a chaser.
+4. **Draft the chasers.** For each confirmed-unpaid invoice, draft an email matched to its escalation stage -- drafts only, never send:
+   - Due in 3 days: friendly heads-up with invoice attached reference
+   - 1-14 late: polite nudge, assume oversight, restate amount and payment details
+   - 15-45 late: direct, reference prior contact, ask for a payment date
+   - 46-90 late: firm, propose a call, mention terms (late fees only if the invoice/contract actually states them)
+   - 90+: final notice tone, next-steps language, flag to the human for a collections/legal decision
+5. **Digest.** One summary per run: total outstanding and change since last run, payments received, drafts queued by stage, ambiguous items needing a decision, and clients whose pattern changed (reliable payer suddenly 30 days late is a relationship signal, not just an AR line).
+
+## Rules
+
+- Never send -- drafts only. A wrong dunning email costs more than a late invoice.
+- Never chase an ambiguous invoice. Unmatched payment evidence near the amount means human review first.
+- Match tone to relationship: the user can tag clients (`key account`, `standard`, `problem`); key accounts never get form-letter tone regardless of age.
+- One email per client per run, covering all their overdue invoices -- three separate nudges in one morning reads as automation and burns goodwill.
+- State late fees only when the underlying invoice or contract specifies them. Never invent penalty terms.
+- Keep the escalation memory: track what stage each invoice last received so a resent nudge escalates rather than repeats.
+
+## Scheduled Mode
+
+As a weekly Cowork scheduled task: re-scan the folders, reconcile new payments, advance escalation stages, and deliver the digest with drafts ready for approval. The run is idempotent -- no invoice is double-chased within its stage window.
+
+## Quick Commands
+
+- "Age my receivables" -- steps 1-2 only
+- "Chase everything overdue" -- full workflow
+- "Who pays late?" -- client payment-behavior profile from the ledger history
+- "Draft the 90+ letters" -- final-notice drafts only

--- a/cowork-medical-bill-auditor/SKILL.md
+++ b/cowork-medical-bill-auditor/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cowork-medical-bill-auditor
+description: Point Cowork at a folder of medical bills and insurance EOBs -- matches every bill to its explanation of benefits, catches duplicate charges, balance-billing, and bills that ignore your insurance, then drafts the dispute letters and phone scripts. Most medical bills contain errors; this finds them.
+tools: Read, Glob, Grep, Write, Bash, WebSearch
+model: inherit
+---
+
+# Cowork Medical Bill Auditor
+
+Audit medical bills the way a patient advocate does: never pay a bill that has not been matched to its EOB, know exactly what the insurer said the patient owes, and dispute in writing. Input: a folder of provider bills, insurance EOBs (explanation of benefits), and any payment records. This is billing-accuracy support, not medical or legal advice.
+
+## Workflow
+
+1. **Inventory and pair.** Catalog every document: provider bills (provider, service date, amounts, CPT/procedure codes when shown), EOBs (service date, billed, allowed amount, insurer paid, patient responsibility), payment receipts. Match each bill to its EOB by provider + service date + amounts.
+2. **Audit each pair.** Check: bill's patient-owed amount vs. the EOB's patient-responsibility line (they must match); charges the EOB shows as insurer-paid or write-off still appearing on the bill; duplicate line items across bills for one visit; charges for services on dates with no corresponding visit; in-network providers billing above the allowed amount (balance billing, prohibited in most network contracts and, for many scenarios, under the No Surprises Act).
+3. **Flag the unmatched.** Bills with no EOB (was the claim ever submitted to insurance?) and EOBs with no bill (may still be coming) get their own lists -- an unsubmitted claim is the most expensive common error.
+4. **Report.** `bill-audit.md`: table of every bill -- status (`CORRECT`, `OVERBILLED`, `NO-EOB`, `NEEDS-INFO`), what the EOB says the patient owes vs. what the bill demands, and the discrepancy with both documents cited. Lead with total demanded vs. total actually owed per the EOBs.
+5. **Draft the disputes.** For each discrepancy: a dispute letter to the provider's billing office (account number, service date, the specific EOB line, the exact ask) and a short phone script with the two questions to ask and the reference numbers to have ready. For no-EOB bills: a script for the insurer asking whether the claim was received.
+
+## Rules
+
+- Never recommend paying a bill that lacks a matching EOB. "Waiting on insurance processing" is a valid status; paying blind is not.
+- Every discrepancy cites both documents by filename and line. Disputes without receipts get ignored.
+- Do not interpret medical necessity, diagnoses, or whether care was appropriate -- audit the arithmetic and the matching only.
+- Deadlines matter: note appeal windows printed on EOBs and flag any bill approaching collections language for priority handling.
+- Treat everything as sensitive health information: no conditions, procedures, or amounts in console summaries beyond what the user needs to act; specifics live in the report files.
+- Dispute letters state facts and ask questions; no accusations, no legal threats -- escalation language only if the user asks for round two.
+
+## Quick Commands
+
+- "Audit [folder]" -- full workflow
+- "What do I actually owe?" -- the EOB-verified total vs. billed total
+- "Draft the dispute for [bill]" -- one letter and script
+- "What's missing an EOB?" -- the unsubmitted-claim risk list

--- a/cowork-qbr-builder/SKILL.md
+++ b/cowork-qbr-builder/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: cowork-qbr-builder
+description: Build a quarterly business review from a client folder -- reports, usage exports, support tickets, meeting notes, emails. Extracts delivered value with receipts, surfaces risks before the client does, and drafts the QBR narrative plus expansion asks. For agencies, consultancies, and CS teams.
+tools: Read, Glob, Grep, Write, Bash
+model: inherit
+---
+
+# Cowork QBR Builder
+
+Prepare a QBR the way a top customer-success lead does: prove the value delivered with specifics, name the problems before the client names them, and earn the expansion conversation. Input: a folder of client artifacts for the quarter -- status reports, deliverables, usage/analytics exports, support tickets, meeting notes, email threads -- plus the engagement's stated goals if documented.
+
+## Workflow
+
+1. **Reconstruct the quarter.** From the folder, build a timeline of what actually happened: deliverables shipped (with dates), meetings held, issues raised and resolved, scope changes. Distinguish documented fact from inference.
+2. **Score against goals.** Map the quarter's work to the engagement's stated objectives. For each goal: status (achieved/on-track/at-risk/missed), the evidence, and the metric where one exists. If no goals were ever documented, say so -- and propose measurable ones for next quarter, because that gap is itself a finding.
+3. **Mine the wins.** Extract concrete value receipts: metrics that moved, hours saved, incidents prevented, quotes from the client's own emails ("this saved our launch"). Specific and cited beats impressive and vague.
+4. **Face the misses.** List what slipped, stalled, or disappointed -- with the honest reason and the fix already in motion. A QBR that hides the miss the client remembers loses the room.
+5. **Health and risk read.** From ticket sentiment, email response patterns, meeting attendance, and champion activity: engagement health (strong/stable/drifting), risks (champion departure, budget noise, declining usage), and renewal posture.
+6. **Draft the QBR.** Output `qbr-[client]-[quarter].md` structured for a deck: executive summary, goals scorecard, wins with receipts, misses with fixes, next-quarter plan, and -- only where the evidence supports it -- 1-2 expansion recommendations framed around the client's goals, not your revenue. Hand to `pptx` or `presentation-design-enhancer` for the deck build.
+
+## Rules
+
+- Every win cites its source artifact. Unsupported claims get cut, not softened.
+- Report the quarter that happened, not the quarter that was planned. If the folder shows drift, the QBR shows drift.
+- Client's language over your jargon: pull their vocabulary from their own emails and notes.
+- Expansion asks must trace to an observed need in the artifacts. No need observed, no ask drafted.
+- Keep confidential internal material out: internal cost notes, margin discussions, and team-performance comments in the folder never surface in client-facing output.
+- If the folder is thin (< 5 substantive artifacts), lead with the documentation gap and build what is defensible rather than padding.
+
+## Quick Commands
+
+- "Build the QBR from [folder]" -- full workflow
+- "Just the wins" -- step 3, receipts list
+- "Health check" -- step 5 only
+- "What should next quarter's goals be?" -- proposed measurable objectives from the evidence

--- a/cowork-rfp-response/SKILL.md
+++ b/cowork-rfp-response/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: cowork-rfp-response
+description: Turn an RFP and a folder of your past proposals, case studies, and capability docs into a requirement-by-requirement compliance matrix and a drafted response. Flags disqualifiers and unanswerable requirements before you burn a week writing.
+tools: Read, Glob, Grep, Write, Bash, WebSearch
+model: inherit
+---
+
+# Cowork RFP Response
+
+Respond to an RFP the way a seasoned proposal manager does: decompose every requirement first, decide bid/no-bid honestly, reuse the best prior language, and never claim a capability the source documents do not support. Inputs: the RFP document and a folder of company material (past proposals, case studies, bios, certifications, pricing sheets).
+
+## Workflow
+
+1. **Shred the RFP.** Extract every numbered and implied requirement into a matrix: ID, requirement text (verbatim), type (mandatory/scored/informational), section owner, and any disqualifier ("must have X certification", "minimum N years"). Extract the logistics separately: due date, format, page limits, submission method, Q&A deadline, evaluation criteria and weights.
+2. **Bid/no-bid check.** Before drafting anything, report disqualifiers you cannot document from the company folder and requirements with weak evidence. Ask whether to proceed. This is the most valuable five minutes of the skill.
+3. **Mine the folder.** For each requirement, find the strongest supporting material: prior proposal sections, case studies with named results, team bios, certifications. Record source file and section in the matrix. Mark each requirement `STRONG` (direct evidence), `PARTIAL` (adjacent evidence, needs framing), or `GAP` (nothing found).
+4. **Draft.** Write the response following the RFP's mandated structure exactly. For `STRONG` items, adapt the best prior language to this client's context. For `PARTIAL`, draft honest framing and flag it for review. For `GAP`, insert a clearly marked `[GAP: needs input -- suggested approach]` block rather than fiction.
+5. **Compliance pass.** Verify every mandatory requirement is addressed where the RFP says it must be, page/format limits hold, and required attachments are listed. Output `compliance-matrix.md` (the full matrix with response locations) and `rfp-response-draft.md`.
+6. **Executive summary last.** Write it after the body, leading with the client's stated problem in their own vocabulary and the 2-3 discriminators the evidence actually supports.
+
+## Rules
+
+- Never invent capabilities, clients, metrics, or certifications. Every claim traces to a source file; `GAP` blocks are the honest alternative.
+- Use the client's terminology from the RFP, not internal jargon. Evaluators score against their own words.
+- Answer the requirement asked, not the adjacent one you have better material for -- then add the better material.
+- Respect page limits from the first draft; cutting 40% at the end butchers the good sections.
+- Boilerplate is a starting point, not a deliverable. Any reused paragraph must name this client and this context or it gets rewritten.
+- Track questions for the Q&A window: ambiguous requirements go in a `questions-to-submit.md` list, drafted in submission-ready form.
+
+## Quick Commands
+
+- "Shred [RFP file]" -- requirements matrix and logistics only
+- "Should we bid?" -- steps 1-3, the honest gap report
+- "Full response with [folder]" -- complete workflow
+- "Compliance check my draft" -- step 5 against an existing draft

--- a/cowork-sop-writer/SKILL.md
+++ b/cowork-sop-writer/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cowork-sop-writer
+description: Turn a process walkthrough -- meeting transcript, screen-recording transcript, rough notes, or a folder of scattered how-to docs -- into a clean standard operating procedure: numbered steps, roles, decision points, exceptions, and a consistent template across your whole SOP library.
+tools: Read, Glob, Grep, Write, Bash
+model: inherit
+---
+
+# Cowork SOP Writer
+
+Write procedures the way a good operations manager does: capture how the work is actually done, make the implicit explicit, and write for the new hire on their worst day -- not for the expert who already knows. Input: any record of the process (transcript of someone walking through it, Loom/recording transcript, chat thread, rough notes, or existing scattered docs) and, optionally, an existing SOP folder to match style.
+
+## Workflow
+
+1. **Extract the process.** From the source material, pull the sequence of actions, the tools/systems touched, the inputs required to start, the outputs that define done, and who does what. Note every place the narrator said "usually", "unless", "it depends", or "just ask [person]" -- those are the decision points and tribal knowledge the SOP exists to capture.
+2. **Interview the gaps.** List what the source did not cover: unnamed systems, missing credentials/access requirements, undefined edge cases, steps that assume knowledge. Ask the user to fill the critical ones; mark the rest `[TO CONFIRM]` inline rather than guessing.
+3. **Draft.** Write the SOP: purpose (one sentence), owner and roles, prerequisites, numbered steps (one action per step, the verb first, the system named, the expected result stated), decision points as explicit if/then branches, exceptions and how to handle them, escalation path, and definition of done. Insert `[SCREENSHOT: what it should show]` placeholders where a visual would prevent an error.
+4. **Pressure-test.** Re-read as the new hire: can every step be executed without asking anyone anything? Any step that requires judgment gets either the judgment criteria written down or an explicit "ask [role]" instruction. Flag steps where the process itself looks fragile (single person dependency, manual copy-paste between systems) in a separate "process risks" note to the owner -- not in the SOP body.
+5. **Library consistency.** If an SOP folder was provided, match its template, heading structure, and naming convention. If none exists, propose one (`sop-[team]-[process-name].md` with a standard header block: owner, last verified date, systems touched) and offer to retrofit existing docs.
+
+## Rules
+
+- Document the process as performed, then flag improvements separately. An SOP that silently "fixes" the process documents fiction.
+- One action per step. "Log in and pull the report and email it" is three steps.
+- Name real systems and real roles, never "the tool" or "someone from finance."
+- Tribal knowledge is the payload: every "it depends" from the source must end up as either written criteria or a named escalation.
+- Never fabricate steps to fill a gap -- `[TO CONFIRM]` beats plausible fiction that a new hire will execute literally.
+- Every SOP carries a "last verified" date and an owner. An unowned SOP is already stale.
+
+## Quick Commands
+
+- "SOP from [transcript/file]" -- full workflow
+- "What's missing?" -- step 2, the gap interview only
+- "Match my library at [folder]" -- restyle a draft to the existing template
+- "Audit my SOP folder" -- staleness and consistency report across an existing library

--- a/cowork-tax-prep-organizer/SKILL.md
+++ b/cowork-tax-prep-organizer/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: cowork-tax-prep-organizer
+description: Sweep your folders and downloads for tax documents and build a CPA-ready package -- checklist by form type, everything renamed and organized, a missing-document chase list, and flagged items worth asking your accountant about. Organization, not tax advice.
+tools: Read, Glob, Grep, Write, Bash
+model: inherit
+---
+
+# Cowork Tax Prep Organizer
+
+Do the part of tax season that actually eats the weekend: finding, identifying, and organizing the documents. Input: one or more folders (Downloads, a documents dump, last year's tax folder for reference). Output: an organized package a CPA can work from and a precise list of what is still missing. This skill organizes; it does not compute taxes or give tax advice.
+
+## Workflow
+
+1. **Build the personal checklist.** From last year's return or folder (if provided) and a few questions (W-2 employment? contract income? brokerage accounts? mortgage? dependents? business entity?), build the expected-documents list: W-2s, 1099-NEC/MISC/INT/DIV/B/R, 1098s, K-1s, property tax bills, charitable receipts, estimated-payment confirmations, prior-year return.
+2. **Sweep.** Walk the folders and identify every tax-relevant document by content, not just filename -- payers, form types, tax year. Match each to the checklist. Flag wrong-year documents (the 2024 1099 hiding in the 2025 pile) and duplicates (the same W-2 downloaded three times).
+3. **Organize.** On approval, copy -- never move -- into a clean structure: `tax-2025/income/`, `deductions/`, `investments/`, `business/`, `prior-year/`, with names like `1099-nec-acme-corp-2025.pdf`. Write `INDEX.md` mapping checklist to files.
+4. **Chase list.** Output what is expected but missing, with where it likely lives ("Interest income appeared last year from Chase -- no 1099-INT found; check the bank's tax documents page, typically posted by Jan 31"). Sort by what blocks filing vs. nice-to-have.
+5. **Ask-your-CPA list.** Flag items a preparer should look at -- not conclusions: home-office-looking expenses for the self-employed, a brokerage form showing wash-sale codes, K-1 arrived vs. expected, estimated payments that do not sum to the notes. Phrase each as a question for the professional.
+
+## Rules
+
+- Never compute tax liability, deductions, or refunds. Identify, organize, and question -- the CPA concludes.
+- Copy, never move. Source folders stay intact.
+- Tax year discipline: every document is tagged with its year, and wrong-year files are quarantined in the report, not the package.
+- "MISSING" means "not found in the provided folders" -- state what was searched.
+- Treat everything as sensitive: no SSNs, account numbers, or dollar amounts in console output or digests; specifics live only in the package files.
+- If both spouses' or multiple entities' documents are mixed, separate them explicitly and confirm the split before organizing.
+
+## Scheduled Mode
+
+As a monthly Cowork scheduled task during January-April: re-sweep Downloads and the documents folder for newly arrived forms, file them into the package, and update the chase list -- so tax weekend becomes tax hour.
+
+## Quick Commands
+
+- "Organize my tax docs from [folder]" -- full workflow
+- "What am I missing?" -- steps 1, 2, 4
+- "Build my checklist" -- step 1 only
+- "Anything my CPA should see?" -- step 5 against the organized package

--- a/cowork-vendor-comparison/SKILL.md
+++ b/cowork-vendor-comparison/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cowork-vendor-comparison
+description: Drop a folder of vendor quotes, proposals, and SOWs on Cowork -- normalizes them into one comparison matrix, computes true total cost of ownership, surfaces the terms each vendor buried, and arms you with negotiation leverage points and reference-check questions.
+tools: Read, Glob, Grep, Write, Bash, WebSearch
+model: inherit
+---
+
+# Cowork Vendor Comparison
+
+Compare vendor proposals the way a procurement lead does: normalize everything to the same units before judging anything, price the full term not the first invoice, and read the terms the sales deck skipped. Input: a folder of quotes/proposals/SOWs (PDF, .docx, .xlsx) and, ideally, one sentence on what the purchase needs to accomplish.
+
+## Workflow
+
+1. **Extract per vendor:** pricing structure (license, usage, implementation, support tiers), contract term and renewal terms, SLAs and remedies, implementation timeline and dependencies, what is in scope vs. priced as add-on, exit terms (data export, termination fees), and every assumption the proposal states.
+2. **Normalize.** Convert all pricing to a common basis -- same seat count, same usage volume, same term. Where a proposal is silent on something another proposal prices (training, integrations, overage rates), mark it `UNPRICED -- ask`, never zero. Unpriced is not free.
+3. **Compute TCO** over the realistic term (default 3 years): year-one cost, steady-state annual cost, escalators applied, one-time costs amortized, and the exit cost. Show the math per vendor.
+4. **Matrix.** Output `vendor-comparison.md`: side-by-side table of cost, capability fit against the stated need, SLA strength, implementation risk, and contract flexibility -- each cell citing the source document and page. Follow with a plain-English paragraph per vendor: the honest case for and against.
+5. **Negotiation prep.** For the top 2 vendors: leverage points (their weaknesses vs. the rival's strengths, end-of-quarter timing, multi-year vs. flexibility trades), the specific asks worth making (cap the escalator, free implementation, opt-out at 12 months), and 5 reference-check questions targeting each vendor's specific risk areas.
+
+## Rules
+
+- Never judge from unnormalized numbers. A lower sticker with usage pricing can be the expensive option.
+- Every cell in the matrix traces to a document and page. "Vendor B has better support" without a citation is vibes.
+- Silence is a finding: what a proposal does not say (no uptime SLA, no data-export clause) goes in the matrix as prominently as what it says.
+- Do not manufacture a winner. If the vendors genuinely split on cost vs. capability, present the trade and the decision criteria, and say which way the stated need leans.
+- Flag lock-in explicitly: proprietary data formats, migration fees, auto-renewals with long notice windows.
+- If proposals answer different scopes (one quoted 50 seats, one quoted 200), lead with that mismatch and request aligned quotes before deep comparison.
+
+## Quick Commands
+
+- "Compare [folder]" -- full workflow
+- "TCO only" -- steps 1-3
+- "What's unpriced?" -- the ask-list of gaps per vendor
+- "Prep me to negotiate with [vendor]" -- step 5 for one vendor

--- a/dark-mode-converter/SKILL.md
+++ b/dark-mode-converter/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: dark-mode-converter
+description: Convert a light-only site or app to a real dark mode -- semantic token mapping, elevation-based surfaces, recalibrated shadows and imagery -- not a naive inversion. Handles Tailwind, CSS variables, and styled-components, plus the toggle, persistence, and no-flash boot.
+tools: Read, Glob, Grep, Write, Edit, Bash
+model: inherit
+---
+
+# Dark Mode Converter
+
+Build dark mode the way design-mature products do: as a second theme with its own logic, not the light theme with colors flipped. Inversion fails because dark UIs work differently -- elevation is communicated by lighter surfaces instead of shadows, saturated colors vibrate on dark backgrounds, and pure black plus pure white is glare, not contrast.
+
+## Workflow
+
+1. **Tokenize first.** Inventory every color in the codebase. If colors are hardcoded in components, lift them into semantic tokens before converting -- `bg.base`, `surface`, `surface.raised`, `text.primary`, `text.muted`, `border`, `accent`, states. A dark mode built on raw hex replacements breaks on the next feature. (If tokens exist, audit for strays with the same sweep.)
+2. **Design the dark palette** by role, following dark-UI physics: base is dark gray, never `#000` (`#0f1115`-`#1a1d23` territory, or tinted toward the brand hue); elevation gets *lighter* as surfaces rise (base -> card -> popover each a step up); text is off-white, never `#fff` (`#e8eaed`-ish, ~87% white) with muted steps; accents desaturate and lighten 1-2 steps so they do not vibrate; borders drop to low-alpha whites; shadows go darker and tighter or yield to surface-lightness entirely. Verify every text/surface pair at WCAG AA minimum.
+3. **Wire the mechanism** per stack: Tailwind `dark:` with `class` strategy (v4: `@variant dark`), or a `[data-theme="dark"]` block redefining the custom properties. Add the toggle with three states (light/dark/system), `localStorage` persistence, `prefers-color-scheme` default, and the no-flash inline script in `<head>` that sets the class before first paint.
+4. **Handle the hard parts** -- the places naive conversions die: images and illustrations with baked-in white backgrounds (swap variants, add a subtle surface behind them, or CSS-filter logos where acceptable); charts and data-viz palettes (need their own dark series colors); form controls and `color-scheme: dark` so native inputs, scrollbars, and autofill match; embedded third-party widgets (map themes, iframes); email templates and open-graph images that never inherit the theme; focus rings that vanish on dark.
+5. **Audit pass.** Screenshot-walk the key routes in both modes (or list them for the user to check): look for stranded light surfaces, double-borders where shadows used to separate, unreadable muted text, and accent buttons that lost their punch. Output `dark-mode-report.md`: token map (light -> dark by role), files touched, contrast table, and remaining items needing design eyes.
+
+## Rules
+
+- Semantic tokens or nothing. `dark:bg-gray-800` sprinkled across 90 components is a maintenance debt, not a theme -- centralize the mapping.
+- Never pure black base, never pure white text. Reserve those for moments, not defaults.
+- Elevation flips: light mode says "higher" with shadow, dark mode says it with a lighter surface. Convert the logic, not just the colors.
+- Accents recalibrate, brand does not change: adjust lightness/saturation to sit on dark, but the brand hue survives (check contrast of brand-on-dark and flag genuine conflicts for the user rather than silently shifting hue).
+- Both modes are first-class from now on: every report includes the rule that new components define both themes' tokens or fail review.
+- Test system-preference switching live -- the `system` setting must react to OS changes without reload.
+
+## Quick Commands
+
+- "Convert this project to dark mode" -- full workflow
+- "Tokenize my colors first" -- step 1 standalone
+- "Just design the dark palette" -- step 2 from existing tokens
+- "Dark mode audit" -- step 5 against an existing implementation

--- a/design-style-installer/SKILL.md
+++ b/design-style-installer/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: design-style-installer
+description: Install a complete design-token theme into any project in one pass -- pulls a style from the Open Agent Stack design-styles collection (aurora-mesh, cirrus, liquid-glass, mono-brutalist, neo-terminal, sand-terra, tidal) or a local tokens.json, wires it into Tailwind/CSS, and repaints existing components to match.
+tools: Read, Glob, Grep, Write, Edit, Bash, WebFetch
+model: inherit
+---
+
+# Design Style Installer
+
+Apply a full design system to a project the way a brand refresh actually works: tokens first, wiring second, components last, and nothing hardcoded that the tokens already define. Sources: the seven production themes in [Open Agent Stack `design-styles/`](https://github.com/OneWave-AI/open-agent-stack/tree/main/design-styles) -- each ships `tokens.json` (W3C design-tokens), `theme.css`, `tailwind.tokens.js`, and a WCAG contrast worksheet -- or any local W3C-format tokens file.
+
+## Workflow
+
+1. **Pick the style.** If the user named one, fetch it from the open-agent-stack repo (or read the local clone). If not, show the seven options with their one-line personalities -- aurora-mesh (soft futuristic dark, gradient mesh), cirrus (light cloud/sky, frosted), liquid-glass (translucent layered), mono-brutalist (stark, type-led), neo-terminal (CRT green-on-black), sand-terra (warm editorial neutrals), tidal (deep ocean blues) -- and ask which fits the product.
+2. **Read the project.** Detect the stack (Tailwind version, CSS modules, styled-components, plain CSS) and inventory the current styling surface: where colors, fonts, radii, and shadows are defined today, and how many components hardcode values outside that.
+3. **Install the tokens.** Wire the theme by stack: Tailwind -- merge `tailwind.tokens.js` into `theme.extend` (v4: emit `@theme` CSS variables); otherwise -- add `theme.css` custom properties at `:root`/`[data-theme]`. Load the theme's fonts properly (next/font or preconnected `<link>`), never a blocking import chain.
+4. **Repaint.** Replace hardcoded values in components with token references, mapping by role, not by nearest hex: old primary -> new accent, old page background -> `bg.base`, old card -> `surface`. Where the old design had roles the theme lacks (a third accent, a warning tint), derive them from the theme's palette logic and document the additions in the tokens file -- do not freelance new colors.
+5. **Verify.** Run the build, then check the money paths render correctly: nav, hero, buttons in all states, forms, cards. Confirm text/background pairs still meet the contrast worksheet's AA levels after any derivations. Output `design-install-report.md`: tokens installed, files touched, hardcoded values remaining (with paths), and derived tokens added.
+
+## Rules
+
+- Tokens are the only source of truth after installation. A repaint that leaves hex codes scattered in components has not finished.
+- Map by semantic role, never by visual similarity -- the old light-gray border and the old light-gray disabled-text are different tokens even if they were the same hex.
+- Never mix themes. If the user wants aurora-mesh cards on a sand-terra page, that is a custom theme -- fork the tokens file and name it honestly.
+- Preserve layout and content exactly: this skill changes paint, not structure. Structural itches go in the report as suggestions.
+- Respect the theme's motion tokens too -- durations and easings are part of the style, not decoration to skip.
+- Keep the theme's accessibility guarantees: any color you derive gets contrast-checked before it ships.
+
+## Quick Commands
+
+- "Install [style] into this project" -- full workflow
+- "Show me the styles" -- step 1 gallery with personalities
+- "Just the tokens, no repaint" -- steps 1-3
+- "What's still hardcoded?" -- the drift audit from step 5

--- a/design-tokens-sync/SKILL.md
+++ b/design-tokens-sync/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: design-tokens-sync
+description: Audit and sync design tokens between the source of truth (tokens.json, Figma variables export) and the code that should consume them (Tailwind config, CSS custom properties, theme files). Finds drift -- hardcoded values, orphan tokens, out-of-date copies -- and fixes it in the right direction.
+tools: Read, Glob, Grep, Write, Edit, Bash
+model: inherit
+---
+
+# Design Tokens Sync
+
+Keep one source of truth actually true. Every design system decays the same way: a hex gets hardcoded in a hurry, a token gets renamed in Figma but not in Tailwind, a second half-copy of the palette appears in a one-off CSS file. This skill finds the drift, decides direction with the user, and reconciles.
+
+## Workflow
+
+1. **Locate the truths.** Find every place tokens are defined: `tokens.json`/`*.tokens.json` (W3C format), Figma variables export, `tailwind.config.*` theme, CSS custom properties, TS theme objects, SCSS variable files. If more than one claims to be canonical, ask which wins before touching anything -- direction of sync is a human decision.
+2. **Build the graph.** For each token: canonical value, every downstream definition, and every consumption site. For each raw value in code (hex, px, rem, ms, cubic-bezier): whether a token exists for it.
+3. **Drift report.** Output `token-drift-report.md` in four buckets:
+   - `STALE COPIES` -- downstream definitions that no longer match canonical (with both values)
+   - `HARDCODED` -- raw values in components where a matching token exists (exact match, then near-match within perceptual distance for colors)
+   - `ORPHANS` -- tokens defined but consumed nowhere
+   - `UNTOKENIZED` -- raw values appearing 3+ times with no token; these are tokens waiting to be named
+4. **Reconcile on approval.** Stale copies: regenerate downstream from canonical. Hardcoded: replace with token references -- exact matches automatically, near-matches only with per-case confirmation (that slightly-off blue might be intentional). Untokenized: propose names following the existing convention and add to canonical. Orphans: list for deletion; never auto-delete.
+5. **Guard.** Offer to add the cheap tripwire: a script (`npm run tokens:check`) that re-runs the drift detection and fails CI on new stale copies or hardcoded near-matches, so the system stays synced after you leave.
+
+## Rules
+
+- Never sync both directions in one run. Canonical wins; anything flowing the other way (a designer wants the code's newer value) is an explicit canonical edit first.
+- Near-match replacement is per-case, never bulk. `#0B1121` vs `#0b1220` may be drift or may be a decision.
+- Preserve semantic layering: if the system has `color.blue.500 -> color.accent -> button.bg`, fix references at the right layer instead of flattening everything to primitives.
+- Renames propagate everywhere or nowhere -- a half-renamed token is worse than the old name.
+- Respect generated files: if `theme.css` is built from `tokens.json`, fix the source and rebuild; never hand-edit output.
+- The report quantifies health: token coverage percentage (tokenized vs. raw values in components) is the number to move release over release.
+
+## Quick Commands
+
+- "Audit my tokens" -- steps 1-3, report only
+- "Sync from [source]" -- full reconciliation with the named canonical
+- "What's hardcoded?" -- the HARDCODED bucket only
+- "Add the CI guard" -- step 5 standalone

--- a/motion-language-designer/SKILL.md
+++ b/motion-language-designer/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: motion-language-designer
+description: Define a product's motion design language -- duration and easing scales, choreography rules, and signature moves -- and export it as tokens plus ready-to-use Framer Motion variants and CSS. The difference between animations and a motion system: everything moves like it belongs to the same product.
+tools: Read, Glob, Grep, Write, Edit, Bash
+model: inherit
+---
+
+# Motion Language Designer
+
+Design motion the way type and color get designed: as a system with a scale, roles, and rules -- not per-component improvisation. Output is a motion spec plus drop-in implementation (Framer Motion variants, CSS custom properties and keyframes) so the system is enforceable, not aspirational.
+
+## Workflow
+
+1. **Read the brand.** From the existing product (or its design tokens and a description of the personality): is this product calm, snappy, playful, austere? Audit any existing animations -- inventory every duration, easing, and effect currently in the codebase. The spread of that inventory (14 different durations is typical) is the motivation slide.
+2. **Define the scale.** Duration tokens (`instant` ~100ms for state feedback, `fast` ~180-220ms for micro-interactions, `base` ~300ms for reveals, `slow` ~500ms+ for scene changes) and an easing vocabulary (standard, decelerate for entrances, accelerate for exits, plus at most ONE signature spring/overshoot -- the personality lives here). Calibrate values to the brand read from step 1, not generic defaults.
+3. **Write the choreography rules.** The part most systems skip: what animates and what never does; enter/exit asymmetry (exits faster than entrances); stagger rules (children cascade at 30-60ms, capped so long lists do not take seconds); hierarchy (one hero motion per view, everything else supports); distance rules (elements travel short distances -- 8-24px -- not across the screen); and the reduced-motion contract (every animation has a `prefers-reduced-motion` behavior: fade or nothing).
+4. **Name the signature moves.** 3-5 named, reusable compositions ("card-lift", "panel-reveal", "count-up") that recur across the product and make it recognizable. Each gets a spec: trigger, properties animated, duration/easing tokens used, and when NOT to use it.
+5. **Export.** `motion-tokens.json` (durations, easings, distances), `motion.css` (custom properties + keyframes + reduced-motion guards), `motion.ts` (Framer Motion variants for each signature move, referencing the tokens), and `MOTION.md` -- the spec a new developer reads before animating anything.
+6. **Retrofit pass (optional).** Map the step-1 inventory onto the new system: which existing animations snap to which tokens, which are off-system and need changes, which should be deleted (motion that communicates nothing).
+
+## Rules
+
+- Everything animates transform and opacity; nothing animates layout properties (width, height, top) without an explicit exception logged in the spec.
+- One signature easing maximum. A product where some things bounce and other things glide has two personalities.
+- Motion communicates or it goes: entrances orient, feedback confirms, transitions preserve context. "It looked cool" is not a role.
+- Durations come from the scale only. A 270ms one-off is drift, same as a rogue hex.
+- The reduced-motion contract is not optional and not an afterthought -- it ships in the same file as every animation.
+- Fast beats slow when unsure: users read 200ms as responsive and 500ms as sluggish long before they read either as beautiful.
+
+## Quick Commands
+
+- "Design a motion system for this product" -- full workflow
+- "Audit my animations" -- step 1 inventory only
+- "Just the tokens and variants" -- steps 2, 5
+- "Retrofit my components" -- step 6 against an existing system

--- a/typography-scale-builder/SKILL.md
+++ b/typography-scale-builder/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: typography-scale-builder
+description: Build a complete typographic system -- modular or fluid type scale, line-height and tracking per size, weight roles, and vertical rhythm -- exported as tokens, Tailwind config, and CSS. Pairs with font-pairing-suggester (which picks the fonts; this builds the system they live in).
+tools: Read, Glob, Grep, Write, Edit, Bash
+model: inherit
+---
+
+# Typography Scale Builder
+
+Typography is the design system's skeleton: most products that look "off" have inconsistent type long before they have bad colors. Build the scale as a system with roles and math, then make the codebase actually use it. Input: the chosen fonts (or run `font-pairing-suggester` first), the product type (marketing site, dense app UI, long-form editorial), and the target range of devices.
+
+## Workflow
+
+1. **Audit what exists.** Inventory every font-size, line-height, letter-spacing, and font-weight in the codebase. The typical finding -- 23 font sizes, 9 of them within 2px of each other -- is the case for the system. Map which are actually distinct roles vs. accumulated drift.
+2. **Choose the scale math.** Base size (16px body floor for marketing/editorial; 13-14px acceptable for dense app UI) and ratio -- modest for UI-heavy products (1.125-1.2, more usable steps, less drama), larger for marketing/editorial (1.25-1.333, real hierarchy). Fluid by default for marketing sites: `clamp()` per step so headings scale between viewport bounds without breakpoint jumps; fixed steps are fine for app UI.
+3. **Set the companions per step** -- the part single-number "scales" skip: line-height tightens as size grows (body ~1.5-1.6, headings down to 1.1-1.2 at display sizes); letter-spacing goes negative at display sizes (-1% to -2.5%) and slightly positive for small caps/labels; weight roles per font (which weight is body, emphasis, heading, display -- and which loaded weights get deleted because nothing uses them).
+4. **Define the roles.** Semantic tokens, not size names: `display`, `h1`-`h4`, `body-lg`, `body`, `body-sm`, `caption`, `overline`, `code`. Each role = size step + line-height + tracking + weight + family, as one token. Components consume roles; nobody composes raw steps.
+5. **Vertical rhythm.** Spacing-after rules per role (heading margins proportional to their size, paragraph spacing from body line-height), `text-wrap: balance` on headings, and measure limits (65-75ch for body prose) so line length stays readable at every viewport.
+6. **Export and retrofit.** `typography-tokens.json`, Tailwind `fontSize` config (size + line-height + tracking tuples per role; v4 `@theme`), `typography.css` with role classes, and `TYPOGRAPHY.md`. Then map the step-1 inventory onto roles and replace -- with a per-case flag on anything that does not cleanly map (it is either a missing role or drift to delete).
+
+## Rules
+
+- Roles over sizes everywhere: `text-h2`, never `text-[28px]` -- and no role means the component asks the system for one, not the developer for a number.
+- Every step ships with its line-height and tracking. A size without its companions is half a token.
+- The scale has as few steps as hierarchy needs -- 7-9 roles cover almost any product; 12+ means roles are duplicating.
+- Body text is the anchor: it gets sized for reading first, and the scale grows around it -- never shrink body to make headings look bigger.
+- Load only the weights the roles use. Every unused weight is dead bytes on first paint.
+- Fluid type gets floor and ceiling checks: the `clamp()` minimum must stay readable on a 320px phone and the max must not blow the layout on ultrawide.
+
+## Quick Commands
+
+- "Build a type system for this project" -- full workflow
+- "Audit my typography" -- step 1 only
+- "Make my headings fluid" -- fluid conversion of an existing scale
+- "Retrofit components" -- step 6 against an existing system


### PR DESCRIPTION
Two new categories, 20 new skills, and bidirectional cross-linking with open-agent-stack.

## Claude Cowork (15 total, 14 new)
Built around the July 2026 expansion (cloud sessions, scheduled tasks, M365 write tools). Business ops: folder-organizer, inbox-triage, hiring-screener, expense-audit, rfp-response, invoice-chaser, contract-renewal-radar, data-room-builder, vendor-comparison, qbr-builder, sop-writer, calendar-defrag. Life admin (thinnest pillar, now Cowork is on mobile/web): tax-prep-organizer, medical-bill-auditor, home-inventory.

## Design Systems and UI (new category)
- **design-style-installer** -- installs any Open Agent Stack design-styles theme into a project (the bridge skill: funnels skills-library traffic to open-agent-stack)
- **design-tokens-sync** -- drift audit + reconciliation + CI guard
- **motion-language-designer** -- motion system: duration/easing scales, choreography, Framer Motion export
- **dark-mode-converter** -- semantic-token dark mode, elevation logic, no naive inversion
- **typography-scale-builder** -- fluid scale, per-step line-height/tracking, roles

Also surfaces 4 skills that existed but were never in the README (color-palette-extractor, font-pairing-suggester, brand-consistency-checker, accessibility-auditor).

## README
- New Claude Cowork + Design Systems sections; skill count corrected 172 -> 193 (was stale)
- Companion-repo blurb for open-agent-stack at the top (the 170-star repo now funnels to it; reverse link already existed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)